### PR TITLE
fix(post): fix `_count` field on post resolver to be a field resolver

### DIFF
--- a/src/post/post.resolver.ts
+++ b/src/post/post.resolver.ts
@@ -57,7 +57,7 @@ export class PostResolver {
       .board()
   }
 
-  @Query(() => PostCount)
+  @ResolveField(() => PostCount)
   async _count(@Root() post: Post): Promise<PostCount> {
     const result = await this.postService.findOne({
       select: { _count: true },


### PR DESCRIPTION
## Summary
- fix `_count` field on post resolver to be a field resolver

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm typecheck` *(fails: tsc command failed)*

------
https://chatgpt.com/codex/tasks/task_e_68444332b7d0832893fd6bbf7bac431d